### PR TITLE
Corrección del error y cambiado el método de conexión con mongo

### DIFF
--- a/src/controllers/room.controller.js
+++ b/src/controllers/room.controller.js
@@ -65,7 +65,7 @@ const createRoom = async function(req, res) {
         if(req.body.authorised_users) {
             authorised_users = req.body.authorised_users;
             if(!is_private && authorised_users.length!=0){
-                console.log('Error. No se puede crear una sala no privada y añadir gente autorizada. ' + err);
+                console.log('Error. No se puede crear una sala no privada y añadir gente autorizada. ');
                 statusCode = 400;
                 statusMessage = 'Form error';
                 nErrores++;

--- a/src/controllers/room.controller.js
+++ b/src/controllers/room.controller.js
@@ -1,6 +1,6 @@
 const bcrypt = require('bcryptjs')
 const parametros = require('../lib/configParameters')
-const mongoose =  require("mongoose");
+const mongodbManager =  require("mongoose");
 const { v4: uuidv4 } = require("uuid");
 
 const mongodbConnection = require('../databases/mongodb/repository/mongodbManager');
@@ -8,13 +8,9 @@ const mongodbRoom = require('../databases/mongodb/models/rooms.model')
 
 // conectar a la bbdd
 var mongoDB = "mongodb://127.0.0.1/studybuddies";
-mongoose.connect(mongoDB, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useFindAndModify: false
-  });
 
-const create = async function(req, res) {
+
+const createRoom = async function(req, res) {
     
     let nErrores = 0;
     let statusCode = 0;
@@ -28,9 +24,10 @@ const create = async function(req, res) {
     let ending_time = new Date();
     let price_per_hour = 0;
     let is_private = false;
+    let authorised_users = [];
     let id_user = "";
 
-    let room_url
+    let room_url;
     let domain = "";
     let options = {
         
@@ -65,6 +62,15 @@ const create = async function(req, res) {
         if(req.body.is_private) {
             is_private = req.body.is_private;
         }
+        if(req.body.authorised_users) {
+            authorised_users = req.body.authorised_users;
+            if(!is_private && authorised_users.length!=0){
+                console.log('Error. No se puede crear una sala no privada y añadir gente autorizada. ' + err);
+                statusCode = 400;
+                statusMessage = 'Form error';
+                nErrores++;
+            }
+        }
         if(req.body.id_user) {
             id_user = req.body.id_user;
         }
@@ -86,6 +92,7 @@ const create = async function(req, res) {
         ending_time : ending_time,
         price_per_hour : price_per_hour,
         is_private : is_private,
+        authorised_users : authorised_users,
         id_user : id_user,
         room_url : "meet.jit.si/studybuddies-"+id
         /*
@@ -112,9 +119,24 @@ const create = async function(req, res) {
     }
 
     // Crear room en BBDD
-    const room = await new mongodbRoom.room(roomBody);
-    room.save();
+    //const room = await new mongodbRoom.Room(roomBody);
 
+    /*
+    PREGUNTAR A ALE 
+    Aquí estaba intentando crear un objeto a partir de la clase definida en el modelo de room  guardarla pero 
+    solo creaba una room vacía (exactamente como está en el modelo de room) asi que he probado a pasarle directamente al 
+    método de guardado el roomBody y así funciona bien. No se si es así como me dijo Ale que lo hiciera pero furula.
+
+     */
+
+    try {
+        await mongodbRoom.guardarRoom(conexionMongodb, roomBody, "rooms");
+    } catch (err) {
+        console.log('Error al crear la conexion con mongodb. ' + err);
+        statusCode = 500;
+        statusMessage = 'Connection error';
+        nErrores++;
+    }
     // Cerramos la conexion mongo
     if (nErrores == 0) 
     {
@@ -133,5 +155,5 @@ const create = async function(req, res) {
 }
 
 module.exports = {
-    create
+    createRoom
 }

--- a/src/databases/mongodb/models/rooms.model.js
+++ b/src/databases/mongodb/models/rooms.model.js
@@ -1,33 +1,38 @@
-const mongoose = require("mongoose");
-const Schema = mongoose.Schema;
 
-const RoomSchema = new Schema({
-    guid: String,
-    description : String,
-    university : String,
-    degree : String,
-    subject : String,
-    starting_time : Date,
-    ending_time : Date,
-    price_per_hour : Number,
-    is_private : {
-        type : Boolean,
-        default : false
-    },
-    id_user : String,
-    room_url : String,
-    /*
-    domain : String,
-    options : {
-        roomName : String,
-        width : Number,
-        height: Number,
-        parentNode: String
+
+class Room {
+    constructor() {
+        this.guid = '',
+        this.description = '',
+        this.university = '',
+        this.degree = '',
+        this.subject = '',
+        this.starting_time = null,
+        this.ending_time = null,
+        this.price_per_hour = 0,
+        this.is_private = null,
+        this.authorised_users = [],
+        this.id_user = 0,
+        this.room_url = ''
     }
-    */
-});
+}
 
-const room = mongoose.model("rooms", RoomSchema);
+const guardarRoom = function(db, room, colRooms) {
+    return new Promise((resolve, reject) => {
+        try {
+            const roomCollection = db.db("studybuddies").collection(colRooms)
+            roomCollection.insertOne(room).then((result) => {
+                resolve()
+            })
+            .catch((err) => {
+                reject(err)
+            })
+        } 
+        catch(err) {
+            reject(err)
+        }
+    })
+}
 
 const getRooms = function (db, dbName) {
     return new Promise((resolve, reject) => {
@@ -45,6 +50,7 @@ const getRooms = function (db, dbName) {
 }
 
 module.exports = {
-    room,
-    getRooms
+    Room,
+    getRooms,
+    guardarRoom
 }

--- a/src/databases/mongodb/repository/mongodbManager.js
+++ b/src/databases/mongodb/repository/mongodbManager.js
@@ -3,7 +3,8 @@ const { MongoClient } = require('mongodb')
 const crearConexion = async function(user, password, dbName) {
     return new Promise(async function(resolve, reject) {
         try {
-            const connStr = `mongodb+srv://${user}:${password}@cluster0.p7sle.mongodb.net/${dbName}?retryWrites=true&w=majority&useUnifiedTopology=true`;
+            const connStr = `mongodb://localhost:27017/?readPeference=primary&appname=MongoDB%20Compass%20Community&ssl=false`;
+            //const connStr = `mongodb+srv://${user}:${password}@cluster0.p7sle.mongodb.net/${dbName}?retryWrites=true&w=majority&useUnifiedTopology=true`;
             resolve(await MongoClient(connStr).connect());
         } catch(err) {
             reject()

--- a/src/routes/room.route.js
+++ b/src/routes/room.route.js
@@ -1,6 +1,6 @@
 const router = require('express').Router()
 const roomController = require('../controllers/room.controller')
 
-router.post('/create', roomController.create);
+router.post('/create', roomController.createRoom);
 
 module.exports = router;


### PR DESCRIPTION
Cambiado el método de conexión con mongo (en vez de usar mongoose se usa el que recomienda el jefe de equipo para que el método sea homogéneo e todo backend) y añadido el atributo authorised_users como la lista de usuarios autorizados necesaria para cuando la sala sea privada.

Además, se ha cambiado una línea respecto al original que provocaba que no se mostrase el mensaje de error adecuado a la hora de crear una sala mal.